### PR TITLE
Changed class binding inline component's styling

### DIFF
--- a/docs/.vuepress/components/Style/ClassBindingInline.vue
+++ b/docs/.vuepress/components/Style/ClassBindingInline.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <button @click="active = !active" :class="{ coolBorder: active }">
-      Click for Dotted lines
+      Click to change button background color
     </button>
   </div>
 </template>
@@ -17,6 +17,7 @@ export default {
 
 <style scoped>
 .coolBorder {
-  border: dotted 1px;
+  background-color: white;
+  color: black;
 }
 </style>


### PR DESCRIPTION
"Click for Dotted lines" to "Click to change button background color"  because 'change border' can't be seen clearly.
Now when click on the button backround color turns white and font color turns black so the difference can be seen clearly.